### PR TITLE
Cached imet scores

### DIFF
--- a/database/IMET.40-sync_imet_records.sql
+++ b/database/IMET.40-sync_imet_records.sql
@@ -1,0 +1,18 @@
+BEGIN;
+
+CREATE TABLE imet.imet_scores
+(
+    id       serial PRIMARY KEY,
+    "UpdateBy" integer,
+    "UpdateDate" character varying(30),
+    "FormID" integer,
+    scores   json,
+    CONSTRAINT "FormID_fk" FOREIGN KEY ("FormID") REFERENCES imet.imet_form ("FormID") MATCH SIMPLE ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+ALTER TABLE imet.imet_form
+    ADD COLUMN IF NOT EXISTS sync_unique_id varchar(40) default null;
+ALTER TABLE imet.imet_form
+    ADD COLUMN IF NOT EXISTS synced boolean default false;
+
+COMMIT;

--- a/src/Controllers/Imet/ReportController.php
+++ b/src/Controllers/Imet/ReportController.php
@@ -2,6 +2,7 @@
 
 namespace AndreaMarelli\ImetCore\Controllers\Imet;
 
+use AndreaMarelli\ImetCore\Models\Imet\ImetScores;
 use Illuminate\Http\Request;
 
 use function view;
@@ -55,7 +56,17 @@ class ReportController extends Controller
         $this->authorize('edit', (static::$form_class)::find($item));
 
         \AndreaMarelli\ImetCore\Models\Imet\v1\Report::updateByForm($item, $request->input('report'));
-        return [ 'status' => 'success' ];
+        return ['status' => 'success'];
+    }
+
+    /**
+     * @param int $form_id
+     * @param array $assessments_scores
+     * @return mixed
+     */
+    public static function report_cache_scores(int $form_id, array $assessments_scores)
+    {
+        return ImetScores::updateOrCreate(['FormID' => $form_id], ['scores' => $assessments_scores]);
     }
 
 }

--- a/src/Controllers/Imet/oecm/ReportController.php
+++ b/src/Controllers/Imet/oecm/ReportController.php
@@ -33,7 +33,10 @@ class ReportController extends BaseReportController
         }
 
         $governance = Modules\Context\Governance::getModuleRecords($form_id);
-        $scores = OEMCStatisticsService::get_scores($form_id, 'ALL');
+        $scores = OEMCStatisticsService::get_scores($form_id, 'ALL', false);
+        if(is_cache_scores_enabled()) {
+            $this->report_cache_scores($form_id, $scores);
+        }
         $key_elements = $this->getKeyElements($form_id);
 
         return [

--- a/src/Controllers/Imet/v1/ReportController.php
+++ b/src/Controllers/Imet/v1/ReportController.php
@@ -47,9 +47,9 @@ class ReportController extends BaseReportController
 
         $general_info = Modules\Context\GeneralInfo::getVueData($form_id);
         $vision = Modules\Context\Missions::getModuleRecords($form_id);
-        $assessments_scores = V1ToV2StatisticsService::get_scores($form_id, 'ALL');
+        $assessments_scores = V1ToV2StatisticsService::get_scores($form_id, 'ALL', false);
         if(is_cache_scores_enabled()) {
-            $this->report_cache_scores($form_id, $assessments_scores['global']);
+            $this->report_cache_scores($form_id, $assessments_scores);
         }
         return [
             'item' => $item,

--- a/src/Controllers/Imet/v1/ReportController.php
+++ b/src/Controllers/Imet/v1/ReportController.php
@@ -32,12 +32,12 @@ class ReportController extends BaseReportController
         $api_available = $show_api = false;
         $wdpa_extent = $dopa_radar = $dopa_indicators = null;
 
-        if(!ProtectedAreaNonWdpa::isNonWdpa($item->wdpa_id)) {
+        if (!ProtectedAreaNonWdpa::isNonWdpa($item->wdpa_id)) {
             $show_api = true;
             $api_available = DOPA::apiAvailable();
             if ($api_available) {
-                $wdpa_extent     = [];
-                $dopa_radar      = DOPA::get_wdpa_radarplot($item->wdpa_id);
+                $wdpa_extent = [];
+                $dopa_radar = DOPA::get_wdpa_radarplot($item->wdpa_id);
                 $dopa_indicators = DOPA::get_wdpa_all_inds($item->wdpa_id);
             }
         } else {
@@ -47,12 +47,15 @@ class ReportController extends BaseReportController
 
         $general_info = Modules\Context\GeneralInfo::getVueData($form_id);
         $vision = Modules\Context\Missions::getModuleRecords($form_id);
-
+        $assessments_scores = V1ToV2StatisticsService::get_scores($form_id, 'ALL');
+        if(is_cache_scores_enabled()) {
+            $this->report_cache_scores($form_id, $assessments_scores['global']);
+        }
         return [
             'item' => $item,
             'key_elements' => [
                 'species' => Modules\Evaluation\ImportanceSpecies::getModule($form_id)
-                    ->pluck('Aspect')->map(function($item){
+                    ->pluck('Aspect')->map(function ($item) {
                         return Str::contains('|', $item) ? Animal::getByTaxonomy($item)->binomial : $item;
                     })->toArray(),
                 'habitats' => Modules\Evaluation\ImportanceHabitats::getModule($form_id)
@@ -62,17 +65,17 @@ class ReportController extends BaseReportController
                 'ecosystem_services' => array_values(Modules\Evaluation\ImportanceEcosystemServices::getPredefined()['values']),
                 'threats' => array_values(Modules\Evaluation\Menaces::getPredefined()['values'])
             ],
-            'assessment' =>  array_merge(
-                V1ToV2StatisticsService::get_scores($form_id, 'ALL'),
+            'assessment' => array_merge(
+                $assessments_scores,
                 [
-                            'labels' => V1ToV2StatisticsService::indicators_labels(\AndreaMarelli\ImetCore\Models\Imet\Imet::IMET_V1)
-                        ]
+                    'labels' => V1ToV2StatisticsService::indicators_labels(\AndreaMarelli\ImetCore\Models\Imet\Imet::IMET_V1)
+                ]
             ),
             'report' => \AndreaMarelli\ImetCore\Models\Imet\v1\Report::getByForm($form_id),
             'connection' => $api_available,
             'show_api' => $show_api,
             'wdpa_extent' => $wdpa_extent[0]->extent ?? null,
-            'dopa_radar' =>  $dopa_radar,
+            'dopa_radar' => $dopa_radar,
             'dopa_indicators' => $dopa_indicators[0] ?? null,
             'show_non_wdpa' => $show_non_wdpa ?? false,
             'non_wdpa' => $non_wdpa ?? null,

--- a/src/Controllers/Imet/v2/ReportController.php
+++ b/src/Controllers/Imet/v2/ReportController.php
@@ -47,8 +47,11 @@ class ReportController extends BaseReportController
         $general_info = Modules\Context\GeneralInfo::getVueData($form_id);
         $vision = Modules\Context\Missions::getModuleRecords($form_id);
 
-        $assessments_scores = V2StatisticsService::get_scores($form_id, 'ALL');
-        $this->report_cache_scores($form_id, $assessments_scores['global']);
+        $assessments_scores = V2StatisticsService::get_scores($form_id, 'ALL', false);
+        if(is_cache_scores_enabled()) {
+            $this->report_cache_scores($form_id, $assessments_scores);
+        }
+
         return [
             'item' => $item,
             'key_elements' => [

--- a/src/Controllers/Imet/v2/ReportController.php
+++ b/src/Controllers/Imet/v2/ReportController.php
@@ -2,7 +2,6 @@
 
 namespace AndreaMarelli\ImetCore\Controllers\Imet\v2;
 
-use AndreaMarelli\ImetCore\Controllers\Imet\EvalController;
 use AndreaMarelli\ImetCore\Controllers\Imet\ReportController as BaseReportController;
 use AndreaMarelli\ImetCore\Models\Imet\v2\Imet;
 use AndreaMarelli\ImetCore\Models\ProtectedAreaNonWdpa;
@@ -11,7 +10,6 @@ use AndreaMarelli\ImetCore\Models\Animal;
 use AndreaMarelli\ImetCore\Services\Statistics\V2StatisticsService;
 use AndreaMarelli\ModularForms\Helpers\API\DOPA\DOPA;
 use Illuminate\Support\Str;
-
 
 
 class ReportController extends BaseReportController
@@ -33,13 +31,13 @@ class ReportController extends BaseReportController
         $api_available = $show_api = false;
         $wdpa_extent = $dopa_radar = $dopa_indicators = null;
 
-        if(!ProtectedAreaNonWdpa::isNonWdpa($item->wdpa_id)){
+        if (!ProtectedAreaNonWdpa::isNonWdpa($item->wdpa_id)) {
             $show_api = true;
             $api_available = DOPA::apiAvailable();
-            if($api_available){
+            if ($api_available) {
                 $wdpa_extent = [];
-                $dopa_radar      = DOPA::get_wdpa_radarplot($item->wdpa_id, true);
-                $dopa_indicators =  DOPA::get_wdpa_all_inds($item->wdpa_id);
+                $dopa_radar = DOPA::get_wdpa_radarplot($item->wdpa_id, true);
+                $dopa_indicators = DOPA::get_wdpa_all_inds($item->wdpa_id);
             }
         } else {
             $show_non_wdpa = true;
@@ -49,29 +47,31 @@ class ReportController extends BaseReportController
         $general_info = Modules\Context\GeneralInfo::getVueData($form_id);
         $vision = Modules\Context\Missions::getModuleRecords($form_id);
 
+        $assessments_scores = V2StatisticsService::get_scores($form_id, 'ALL');
+        $this->report_cache_scores($form_id, $assessments_scores['global']);
         return [
             'item' => $item,
             'key_elements' => [
-                'species' => Modules\Evaluation\ImportanceSpecies::getModule($form_id)->filter(function ($item){
+                'species' => Modules\Evaluation\ImportanceSpecies::getModule($form_id)->filter(function ($item) {
                     return $item['IncludeInStatistics'];
-                })->pluck('Aspect')->map(function($item){
+                })->pluck('Aspect')->map(function ($item) {
                     return Str::contains('|', $item) ? Animal::getByTaxonomy($item)->binomial : $item;
                 })->toArray(),
-                'habitats' => Modules\Evaluation\ImportanceHabitats::getModule($form_id)->filter(function ($item){
+                'habitats' => Modules\Evaluation\ImportanceHabitats::getModule($form_id)->filter(function ($item) {
                     return $item['IncludeInStatistics'];
                 })->pluck('Aspect')->toArray(),
-                'climate_change' => Modules\Evaluation\ImportanceClimateChange::getModule($form_id)->filter(function ($item){
+                'climate_change' => Modules\Evaluation\ImportanceClimateChange::getModule($form_id)->filter(function ($item) {
                     return $item['IncludeInStatistics'];
                 })->pluck('Aspect')->toArray(),
-                'ecosystem_services' => Modules\Evaluation\ImportanceEcosystemServices::getModule($form_id)->filter(function ($item){
+                'ecosystem_services' => Modules\Evaluation\ImportanceEcosystemServices::getModule($form_id)->filter(function ($item) {
                     return $item['IncludeInStatistics'];
                 })->pluck('Aspect')->toArray(),
-                'threats' => Modules\Evaluation\Menaces::getModule($form_id)->filter(function ($item){
+                'threats' => Modules\Evaluation\Menaces::getModule($form_id)->filter(function ($item) {
                     return $item['IncludeInStatistics'];
                 })->pluck('Aspect')->toArray(),
             ],
-            'assessment' =>  array_merge(
-                V2StatisticsService::get_scores($form_id, 'ALL'),
+            'assessment' => array_merge(
+                $assessments_scores,
                 [
                     'labels' => V2StatisticsService::indicators_labels(\AndreaMarelli\ImetCore\Models\Imet\Imet::IMET_V2)
                 ]
@@ -80,7 +80,7 @@ class ReportController extends BaseReportController
             'connection' => $api_available,
             'show_api' => $show_api,
             'wdpa_extent' => $wdpa_extent[0]->extent ?? null,
-            'dopa_radar' =>  $dopa_radar,
+            'dopa_radar' => $dopa_radar,
             'dopa_indicators' => $dopa_indicators[0] ?? null,
             'show_non_wdpa' => $show_non_wdpa ?? false,
             'non_wdpa' => $non_wdpa ?? null,

--- a/src/Jobs/PopulateImetScores.php
+++ b/src/Jobs/PopulateImetScores.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace AndreaMarelli\ImetCore\Jobs;
+
+use AndreaMarelli\ImetCore\Controllers\Imet\ReportController;
+use AndreaMarelli\ImetCore\Services\Statistics\V1ToV2StatisticsService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use AndreaMarelli\ImetCore\Models\Imet\Imet;
+use AndreaMarelli\ImetCore\Services\Statistics\V2StatisticsService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * use this job to update assessments effectiveness scores
+ * every time a change is made in an assessment
+ * It will cache the scores pre imet in json format
+ */
+class PopulateImetScores implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+    use Utils;
+
+    private string $log_label = 'Job Polulate Imet Scores :';
+
+    private function updateRecords($records){
+        foreach($records as $record){
+            if($record->version ===Imet::IMET_V2) {
+                $assessments = V2StatisticsService::get_scores($record->FormID, 'ALL');
+            } else {
+                $assessments = V1ToV2StatisticsService::get_scores($record->FormID, 'ALL');
+            }
+            Log::info($this->log_label.' Insert record .'.$record->FormID);
+            $imet = ReportController::report_cache_scores($record->FormID, $assessments);
+            $imet->touch();
+            Log::info($this->log_label.' '.$imet->UpdateDate);
+        }
+    }
+
+    public function handle()
+    {
+        Log::info($this->log_label.' started.');
+        $timestamp = now()->toDateTimeString();
+
+        if (Storage::exists('job-timestamp.txt')) {
+            $previousTimestamp = Storage::get('job-timestamp.txt');
+            Log::info($this->log_label.' timestamp exist.  '.$previousTimestamp);
+            $records = Imet::select(['FormID', 'version'])->where('UpdateDate', '>', $previousTimestamp)->get();
+            $this->updateRecords($records);
+            Storage::put('job-timestamp.txt', $timestamp);
+            Log::info($this->log_label.' timestamp stored.  '.$timestamp);
+        } else {
+            $records = Imet::select(['FormID', 'version'])->get();
+            Log::info('Retrieved records. '.$records->count());
+            $this->updateRecords($records);
+            Storage::put('job-timestamp.txt', $timestamp);
+            Log::info($this->log_label.' timestamp stored  '.$timestamp);
+
+        }
+        Log::info($this->log_label.' Ended.');
+    }
+}

--- a/src/Models/Imet/API/Assessment/ReportV2.php
+++ b/src/Models/Imet/API/Assessment/ReportV2.php
@@ -2,16 +2,12 @@
 
 namespace AndreaMarelli\ImetCore\Models\Imet\API\Assessment;
 
-
-use AndreaMarelli\ImetCore\Models\Animal;
-
 use AndreaMarelli\ImetCore\Models\Imet\v2\Modules\Context\GeneralInfo;
 use AndreaMarelli\ImetCore\Models\Imet\v2\Modules\Context\Areas;
 use AndreaMarelli\ImetCore\Models\Imet\v2\Modules;
+use AndreaMarelli\ImetCore\Services\Statistics\V2StatisticsService;
 use Illuminate\Support\Facades\Lang;
 use AndreaMarelli\ImetCore\Models\Imet\v2\Report;
-use Illuminate\Support\Str;
-
 
 class ReportV2 extends ReportV1
 {
@@ -24,27 +20,9 @@ class ReportV2 extends ReportV1
      * @param int $form_id
      * @return array
      */
-    protected static function get_key_elements(int $form_id): array
+    protected static function assessment_scores(int $form_id): array
     {
-        return [
-            'species' => Modules\Evaluation\ImportanceSpecies::getModule($form_id)->filter(function ($item) {
-                return $item['IncludeInStatistics'];
-            })->pluck('Aspect')->map(function ($item) {
-                return Str::contains('|', $item) ? Animal::getByTaxonomy($item)->binomial : $item;
-            })->toArray(),
-            'habitats' => Modules\Evaluation\ImportanceHabitats::getModule($form_id)->filter(function ($item) {
-                return $item['IncludeInStatistics'];
-            })->pluck('Aspect')->toArray(),
-            'climate_change' => Modules\Evaluation\ImportanceClimateChange::getModule($form_id)->filter(function ($item) {
-                return $item['IncludeInStatistics'];
-            })->pluck('Aspect')->toArray(),
-            'ecosystem_services' => Modules\Evaluation\ImportanceEcosystemServices::getModule($form_id)->filter(function ($item) {
-                return $item['IncludeInStatistics'];
-            })->pluck('Aspect')->toArray(),
-            'threats' => Modules\Evaluation\Menaces::getModule($form_id)->filter(function ($item) {
-                return $item['IncludeInStatistics'];
-            })->pluck('Aspect')->toArray(),
-        ];
+        return V2StatisticsService::get_scores($form_id, 'ALL');
     }
 
     /**

--- a/src/Models/Imet/API/Statistics/GlobalStatistics.php
+++ b/src/Models/Imet/API/Statistics/GlobalStatistics.php
@@ -28,7 +28,6 @@ class GlobalStatistics
         $wdpa_ids = [];
         $imet_index_average = [];
         $list_v2 = v2\Imet::whereIn('FormID', $form_ids)->select(['wdpa_id', 'FormID', 'version'])->get();
-
         $list_v1 = v1\Imet::whereIn('FormID', $form_ids)->select(['wdpa_id', 'FormID', 'version'])->get();
 
         $list = $list_v1->merge($list_v2);
@@ -348,7 +347,7 @@ class GlobalStatistics
                 ->pluck('FormID')
                 ->toArray();
         }
-        //dd($form_ids);
+
         return $form_ids;
     }
 
@@ -356,6 +355,7 @@ class GlobalStatistics
      * @param Imet $item
      * @param string $name
      * @param int $i
+     * @param bool $global_scores
      * @return array
      */
     public static function pas_rating_fields(Imet $item, string $name, int $i = 1, bool $global_scores = false): array

--- a/src/Models/Imet/ImetScores.php
+++ b/src/Models/Imet/ImetScores.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace AndreaMarelli\ImetCore\Models\Imet;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Log;
+
+class ImetScores extends Model
+{
+    /**
+     * @var string[]
+     */
+    protected $table = 'imet.imet_scores';
+    protected $fillable = ['FormID', 'scores'];
+    protected $casts = [
+        'scores' => 'json'
+    ];
+
+    public const CREATED_AT = 'UpdateDate';
+    public const UPDATED_AT = 'UpdateDate';
+
+    /**
+     * Indicates whether the `updated_at` timestamp should always be updated.
+     *
+     * @var bool
+     */
+    protected $alwaysUpdateUpdatedAt = true;
+
+    /**
+     * Update the model's update timestamp when using updateOrInsert or updateOrCreate.
+     *
+     * @return bool
+     */
+    protected function shouldUpdateUpdatedAt(): bool
+    {
+        return $this->alwaysUpdateUpdatedAt;
+    }
+
+    /**
+     * Manually update the "updated_at" timestamp.
+     *
+     * @return $this
+     */
+    public function touch()
+    {
+        $this->timestamps = false;
+        $this->UpdateDate = $this->freshTimestamp();
+        $this->save();
+        $this->timestamps = true;
+        Log::info('Job Polulate Imet Scores : update timestamp ' . $this->UpdateDate . ' to ' . $this->freshTimestamp());
+        return $this;
+    }
+}

--- a/src/Services/Statistics/StatisticsService.php
+++ b/src/Services/Statistics/StatisticsService.php
@@ -50,10 +50,10 @@ abstract class StatisticsService
      * @param string $step
      * @return array
      */
-    public static function get_scores($imet, string $step = self::GLOBAL): array
+    public static function get_scores($imet, string $step = self::GLOBAL, bool $cache = true): array
     {
         $imet = static::get_imet($imet);
-        if (is_cache_scores_enabled()) {
+        if (is_cache_scores_enabled() && $cache) {
             $scores = static::get_cached_scores($imet);
             if($scores){
                 return $scores;

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -5,6 +5,13 @@ use Illuminate\Support\Str;
 
 
 /**
+ * @return mixed
+ */
+function is_cache_scores_enabled(){
+    return env("CACHED_SCORES", false);
+}
+
+/**
  * Check if App::environment is IMET related (ex. imetoffline or imetglobal)
  *
  * @return bool
@@ -33,7 +40,7 @@ function imet_offline_version()
  */
 function imet_selection_lists(string $type): array
 {
-    $list  = [];
+    $list = [];
 
     if (Str::startsWith($type, 'ImetV1')
         || Str::startsWith($type, 'ImetV2')
@@ -50,7 +57,7 @@ function imet_selection_lists(string $type): array
             $list = \AndreaMarelli\ImetCore\Models\Currency::imetV1List();
         } elseif ($matches[1] != "") {
 
-            $list = trans('imet-core::'.strtolower($matches[1]).'_lists.' . $matches[2]);
+            $list = trans('imet-core::' . strtolower($matches[1]) . '_lists.' . $matches[2]);
         }
 
     }


### PR DESCRIPTION
I created a branch to solve a problem that we will/might have in the global imet.
The index page is taking too long to load because of the assessments scores. I have the same problem with the statistics in the api.
So i created a cache table to keep only the imet scores 
This table will be filled in when the user go to the report page of an imet or with a scheduler that will run a job in the background. This job will check to see if any changes have been made in order to update the cached table with the latest scores. (compare the updateDated in the imet_form with a txt file that will keep the last date the job ran)

The mechanism/workflow will only run when the env variable exist and is true
CACHED_SCORES=true